### PR TITLE
fix typo

### DIFF
--- a/cppguide.ja.html
+++ b/cppguide.ja.html
@@ -8174,7 +8174,7 @@ bool Derived::Equal(Base* other) {
                                     Use the <code>LL</code> or <code>ULL</code>
                                     suffixes as needed to create 64-bit constants.
                                 </span>
-                                64ビット定数を作るためには、<code>LL</code>か<code>ULL</code>といった接頭辞を使ってください。
+                                64ビット定数を作るためには、<code>LL</code>か<code>ULL</code>といった接尾辞を使ってください。
                             </span>
                             <span>
                                 <span class="src">


### PR DESCRIPTION
接頭辞 -> 接尾辞。英文的にはsuffixは接尾辞ですし、内容も接尾辞を指すため。