### PR TITLE
fix a typo on L4926

### DIFF
--- a/cppguide.ja.html
+++ b/cppguide.ja.html
@@ -4923,7 +4923,7 @@ Prefer not to overload the other comparison and ordering operators.
                 If a test fixture class is defined outside of the <code>.cc</code> file it is used in, for example in a <code>.h</code> file,
                 make data members <code>private</code>.
             </span>
-            ただし、テストフィクスチャクラスが、そのクラスを利用する <code>.cc</code> ファイル外で定義される場合(たとえば <code>.h</code>.h ファイル内)は、データメンバは<code>private</code>にしてください。
+            ただし、テストフィクスチャクラスが、そのクラスを利用する <code>.cc</code> ファイル外で定義される場合(たとえば <code>.h</code> ファイル内)は、データメンバは<code>private</code>にしてください。
         </span>
     </p>
     <h3 id="Declaration_Order">


### PR DESCRIPTION
## Changes

Fix a typo on L4926 `<code>.h</code>.h ファイル内)は` to `<code>.h</code> ファイル内)は`

<img width="813" alt="image" src="https://github.com/ttsuki/styleguide/assets/6651854/38393928-6473-4b14-b3e7-0335f4d8a7b2">

